### PR TITLE
better search algorithm to find PEVerify.exe

### DIFF
--- a/Tools/peverify.bat
+++ b/Tools/peverify.bat
@@ -1,14 +1,13 @@
-rem this is a bit dirty here, but I found no other way to locate peverify
+@echo off
 
-rem if you have any other path, duplicate the lines below and add your own path
-set peverify="C:\Program Files (x86)\Microsoft SDKs\Windows\v8.1A\bin\NETFX 4.5.1 Tools\PEVerify.exe"
-if exist %peverify% goto verify
+rem search for newest PEVerify.exe
 
-set peverify="C:\Program Files (x86)\Microsoft SDKs\Windows\v7.0A\Bin\NETFX 4.0 Tools\PEVerify.exe"
-if exist %peverify% goto verify
+set searchdir="%ProgramFiles(x86)%\Microsoft SDKs\Windows"
 
-set peverify="C:\Program Files (x86)\Microsoft SDKs\Windows\v7.0A\Bin\PEVerify.exe"
-if exist %peverify% goto verify
+FOR /F "tokens=*" %%I IN ('DIR %searchdir%\*PEVerify.exe /s/b /od') DO SET peverify=%%I&& GOTO :next
+
+:next
+if exist "%peverify%" goto verify
 
 echo peverify not found, skipping this step
 
@@ -20,6 +19,7 @@ rem muted errors as follow (not sure muting them is good, but they are no valid 
 rem 0x801318BF because an advised ctor can call the base class ctor
 rem 0x80131859 warning of 'this' being unitialized in ctor
 rem 0x8013184F because .ctor inner (wrapped original) method calls base..ctor()
-if exist "%1" %peverify% /nologo /hresult /ignore=0x801318BF,0x80131859,0x8013184F %1
+
+if exist "%1" "%peverify%" /nologo /hresult /ignore=0x801318BF,0x80131859,0x8013184F %1
 
 :noverify


### PR DESCRIPTION
peverify.bat now searches in "%ProgramFiles(x86)%\Microsoft SDKs\Windows" für newest PEVerify.exe